### PR TITLE
remove afero constraint

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -276,13 +276,13 @@
   version = "v2.0.1"
 
 [[projects]]
+  branch = "master"
   name = "github.com/spf13/afero"
   packages = [
     ".",
     "mem"
   ]
-  revision = "63644898a8da0bc22138abf860edaf5277b6102e"
-  version = "v1.1.0"
+  revision = "787d034dfe70e44075ccc060d346146ef53270ad"
 
 [[projects]]
   name = "github.com/spf13/pflag"
@@ -511,6 +511,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "3d92a1865b4fbf32b6b49135101f104c62c5b8e5074bd0ad513ff8dd8083f12c"
+  inputs-digest = "14d20dc330e9ed6faabbd0921d2f8a45452bd8fa53dc14fff8c42c25a8175f74"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -45,11 +45,6 @@
   branch = "master"
   name = "github.com/giantswarm/micrologger"
 
-[[constraint]]
-  name = "github.com/spf13/afero"
-  version = "1.1.0"
-
-
 
 [prune]
   go-tests = true

--- a/vendor/github.com/spf13/afero/mem/file.go
+++ b/vendor/github.com/spf13/afero/mem/file.go
@@ -131,6 +131,9 @@ func (f *File) Sync() error {
 }
 
 func (f *File) Readdir(count int) (res []os.FileInfo, err error) {
+	if !f.fileData.dir {
+		return nil, &os.PathError{Op: "readdir", Path: f.fileData.name, Err: errors.New("not a dir")}
+	}
 	var outLength int64
 
 	f.fileData.Lock()


### PR DESCRIPTION
Aims to prevent a dependency conflict when updating e2e-harness dep. We usually don't impose constraints on afero version.