### PR TITLE
Adds PullChartTarballFromChannel function

### DIFF
--- a/apprclient.go
+++ b/apprclient.go
@@ -145,13 +145,8 @@ func (c *Client) PromoteChart(name, release, channel string) error {
 }
 
 // PullChartTarball downloads a tarball with the chart described by the given
-// chart name and channel, returning the file path.
-func (c *Client) PullChartTarball(name, channel string) (string, error) {
-	release, err := c.GetReleaseVersion(name, channel)
-	if err != nil {
-		return "", microerror.Mask(err)
-	}
-
+// chart name and release, returning the file path.
+func (c *Client) PullChartTarball(name, release string) (string, error) {
 	p := path.Join("packages", c.organization, name, release, "helm", "pull")
 
 	req, err := c.newRequest("GET", p)
@@ -165,6 +160,17 @@ func (c *Client) PullChartTarball(name, channel string) (string, error) {
 	}
 
 	return chartTarballPath, nil
+}
+
+// PullChartTarballFromChannel downloads a tarball with the chart described by
+// the given chart name and channel, returning the file path.
+func (c *Client) PullChartTarballFromChannel(name, channel string) (string, error) {
+	release, err := c.GetReleaseVersion(name, channel)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	return c.PullChartTarball(name, release)
 }
 
 // PushChartTarball sends a tarball to the server to be installed for the given

--- a/apprclient.go
+++ b/apprclient.go
@@ -144,7 +144,7 @@ func (c *Client) PromoteChart(name, release, channel string) error {
 	return nil
 }
 
-// PullChartTarballFromChannel downloads a tarball with the chart described by
+// PullChartTarball downloads a tarball with the chart described by
 // the given chart name and channel, returning the file path.
 func (c *Client) PullChartTarball(name, channel string) (string, error) {
 	release, err := c.GetReleaseVersion(name, channel)
@@ -155,8 +155,8 @@ func (c *Client) PullChartTarball(name, channel string) (string, error) {
 	return c.PullChartTarballFromRelease(name, release)
 }
 
-// PullChartTarball downloads a tarball with the chart described by the given
-// chart name and release, returning the file path.
+// PullChartTarballFromRelease downloads a tarball with the chart described
+// by the given chart name and release, returning the file path.
 func (c *Client) PullChartTarballFromRelease(name, release string) (string, error) {
 	p := path.Join("packages", c.organization, name, release, "helm", "pull")
 

--- a/apprclient.go
+++ b/apprclient.go
@@ -144,9 +144,20 @@ func (c *Client) PromoteChart(name, release, channel string) error {
 	return nil
 }
 
+// PullChartTarballFromChannel downloads a tarball with the chart described by
+// the given chart name and channel, returning the file path.
+func (c *Client) PullChartTarball(name, channel string) (string, error) {
+	release, err := c.GetReleaseVersion(name, channel)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	return c.PullChartTarballFromRelease(name, release)
+}
+
 // PullChartTarball downloads a tarball with the chart described by the given
 // chart name and release, returning the file path.
-func (c *Client) PullChartTarball(name, release string) (string, error) {
+func (c *Client) PullChartTarballFromRelease(name, release string) (string, error) {
 	p := path.Join("packages", c.organization, name, release, "helm", "pull")
 
 	req, err := c.newRequest("GET", p)
@@ -160,17 +171,6 @@ func (c *Client) PullChartTarball(name, release string) (string, error) {
 	}
 
 	return chartTarballPath, nil
-}
-
-// PullChartTarballFromChannel downloads a tarball with the chart described by
-// the given chart name and channel, returning the file path.
-func (c *Client) PullChartTarballFromChannel(name, channel string) (string, error) {
-	release, err := c.GetReleaseVersion(name, channel)
-	if err != nil {
-		return "", microerror.Mask(err)
-	}
-
-	return c.PullChartTarball(name, release)
 }
 
 // PushChartTarball sends a tarball to the server to be installed for the given

--- a/apprclient_test.go
+++ b/apprclient_test.go
@@ -164,7 +164,7 @@ func Test_PullTarball(t *testing.T) {
 				t.Errorf("could not create appr %v", err)
 			}
 
-			path, err := a.PullChartTarball(name, channel)
+			path, err := a.PullChartTarballFromChannel(name, channel)
 			switch {
 			case err != nil && !tc.expectedError:
 				t.Errorf("failed to get release %v", err)

--- a/apprclient_test.go
+++ b/apprclient_test.go
@@ -164,7 +164,7 @@ func Test_PullTarball(t *testing.T) {
 				t.Errorf("could not create appr %v", err)
 			}
 
-			path, err := a.PullChartTarballFromChannel(name, channel)
+			path, err := a.PullChartTarball(name, channel)
 			switch {
 			case err != nil && !tc.expectedError:
 				t.Errorf("failed to get release %v", err)

--- a/spec.go
+++ b/spec.go
@@ -13,7 +13,8 @@ const (
 // Interface describes the methods provided by the appr client.
 type Interface interface {
 	GetReleaseVersion(name, channel string) (string, error)
-	PullChartTarball(name, channel string) (string, error)
+	PullChartTarball(name, release string) (string, error)
+	PullChartTarballFromChannel(name, channel string) (string, error)
 }
 
 // Channel represents a CNR channel.

--- a/spec.go
+++ b/spec.go
@@ -13,8 +13,8 @@ const (
 // Interface describes the methods provided by the appr client.
 type Interface interface {
 	GetReleaseVersion(name, channel string) (string, error)
-	PullChartTarball(name, release string) (string, error)
-	PullChartTarballFromChannel(name, channel string) (string, error)
+	PullChartTarball(name, channel string) (string, error)
+	PullChartTarballFromRelease(name, release string) (string, error)
 }
 
 // Channel represents a CNR channel.


### PR DESCRIPTION
This is something I encountered when I tried to use this in `e2e-harness`. The way I understand this is that we want to use `apprclient` to fetch the chart tarball from our CNR - so most likely quay. 

The large majority of our charts is not in a channel during e2e tests if I understood that right. 

So I made `PullChartTarball` use the release by default and moved the additional logic to a new function called `PullChartTarballFromChannel`. AFAIK I need to take care of `chart-operator` to not break stuff when I update the vendor. 