### PR TITLE
Check StatusCode when doing HTTP GET requests

### DIFF
--- a/apprclient.go
+++ b/apprclient.go
@@ -271,7 +271,7 @@ func (c *Client) doFile(req *http.Request) (string, error) {
 		if err != nil {
 			return "", microerror.Mask(err)
 		}
-		return "", microerror.Maskf(invalidStatusCodeError, fmt.Sprintf("Got StatusCode %d with body %s", resp.StatusCode, buf.String()))
+		return "", microerror.Maskf(invalidStatusCodeError, fmt.Sprintf("got StatusCode %d with body %s", resp.StatusCode, buf.String()))
 	}
 
 	tmpfile, err := afero.TempFile(c.fs, "", "chart-tarball")

--- a/apprclient.go
+++ b/apprclient.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -264,6 +265,14 @@ func (c *Client) doFile(req *http.Request) (string, error) {
 		return "", microerror.Mask(err)
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		buf := new(bytes.Buffer)
+		_, err = buf.ReadFrom(resp.Body)
+		if err != nil {
+			return "", microerror.Mask(err)
+		}
+		return "", microerror.Maskf(invalidStatusCodeError, fmt.Sprintf("Got StatusCode %d with body %s", resp.StatusCode, buf.String()))
+	}
 
 	tmpfile, err := afero.TempFile(c.fs, "", "chart-tarball")
 	if err != nil {

--- a/error.go
+++ b/error.go
@@ -9,6 +9,13 @@ func IsInvalidConfig(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
 }
 
+var invalidStatusCodeError = microerror.New("invalid statuscode")
+
+// IsInvalidStatusCode asserts invalidStatusCodeError.
+func IsInvalidStatusCode(err error) bool {
+	return microerror.Cause(err) == invalidStatusCodeError
+}
+
 var unknownStatusError = microerror.New("unknown status")
 
 // IsUnknownStatus asserts unknownStatusError.


### PR DESCRIPTION
New change looks like this in a `t.fatal` when something goes wrong:
```
Got StatusCode 422 with body {"error":{"code":"invalid-release","details":{"release":"stable"},"message":"Invalid requirement specification: u'stable'"}}
		: invalid statuscode
```
Previously no error was thrown and the body was written to a file which was treated as valid output. 

Uncertain if the error could be matched directly but this should at least be an improvement.