### PR TITLE
readme: add aws-operator to dependent projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,5 +17,6 @@ against some CNR implementation.
 
 ### Services & operators
 
+- https://github.com/giantswarm/aws-operator
 - https://github.com/giantswarm/chart-operator
 - https://github.com/giantswarm/cluster-operator


### PR DESCRIPTION
It uses it in draining e2e test.