### PR TITLE
Don't return error in apprclienttest constructor

### DIFF
--- a/apprclienttest/apprclient.go
+++ b/apprclienttest/apprclient.go
@@ -17,13 +17,13 @@ type Client struct {
 	defaultReleaseVersion string
 }
 
-func New(config Config) (apprclient.Interface, error) {
+func New(config Config) apprclient.Interface {
 	c := &Client{
 		defaultError:          config.DefaultError,
 		defaultReleaseVersion: config.DefaultReleaseVersion,
 	}
 
-	return c, nil
+	return c
 }
 
 func (c *Client) DeleteRelease(ctx context.Context, name, release string) error {

--- a/apprclienttest/apprclient_test.go
+++ b/apprclienttest/apprclient_test.go
@@ -5,11 +5,6 @@ import (
 )
 
 func Test_New(t *testing.T) {
-	c := Config{}
-
 	// Test that New doesn't panic and apprclient.Interface is implemented.
-	_, err := New(c)
-	if err != nil {
-		t.Fatalf("error == %#v, want nil", err)
-	}
+	New(Config{})
 }


### PR DESCRIPTION
When vendoring in chart-operator I found a problem with the interface. Since its a test package returning the error doesn't make sense.

`apprclienttest.New(apprclienttest.Config{})` keeps the unit tests simpler. 